### PR TITLE
Feat/server config

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cali_cli"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Cali's codegen and cli application"
@@ -14,7 +14,7 @@ convert_case = "0.5.0"
 proc-macro2 = { version = "1.0.66", features = ["default", "span-locations"] }
 syn = { version = "2.0" }
 serde = { version = "1.0", features = ["derive"] }
-cali_core = "0.2.0"
+cali_core = "0.3.0"
 clap = { version = "4.0.22", features = ["derive"] }
 quote = "1.0"
 pluralizer = "0.4.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,6 +20,9 @@ quote = "1.0"
 pluralizer = "0.4.0"
 rust-format = "0.3.4"
 
+[dev-dependencies]
+assert_cmd = "2.0.12"
+
 [[bin]]
 name = "cali"
 path = "src/entry/main.rs"

--- a/cli/src/entry/main.rs
+++ b/cli/src/entry/main.rs
@@ -1,5 +1,5 @@
-use clap::{Parser, Subcommand};
 use cali_cli::scaffold::{controller::sync_protos_with_controllers, store::create_store};
+use clap::{Parser, Subcommand};
 
 /// Cali CLI
 /// Create a new application with New

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod scaffold;
+
+pub static CORE_VERSION: &str = "0.2.1";
+pub static DERIVE_VERSION: &str = "0.2.1";

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,4 +1,4 @@
 pub mod scaffold;
 
-pub static CORE_VERSION: &str = "0.2.1";
-pub static DERIVE_VERSION: &str = "0.2.1";
+pub static CORE_VERSION: &str = "0.3.0";
+pub static DERIVE_VERSION: &str = "0.3.0";

--- a/cli/src/scaffold/new.rs
+++ b/cli/src/scaffold/new.rs
@@ -3,6 +3,8 @@ use std::{fs, path::Path};
 
 use tinytemplate::TinyTemplate;
 
+use crate::{CORE_VERSION, DERIVE_VERSION};
+
 pub fn create_app(name: &str) {
     create_directories(name);
     create_files(name);
@@ -40,6 +42,8 @@ fn create_directories(name: &str) {
 #[derive(Serialize)]
 struct Context {
     name: String,
+    core_version: &'static str,
+    derive_version: &'static str,
 }
 
 // Template static strings
@@ -97,6 +101,8 @@ fn create_files(name: &str) {
     ];
     let context = Context {
         name: name.to_string(),
+        core_version: CORE_VERSION,
+        derive_version: DERIVE_VERSION,
     };
 
     files.iter().for_each(|(content, path)| {

--- a/cli/templates/Cargo.toml.tt
+++ b/cli/templates/Cargo.toml.tt
@@ -5,3 +5,4 @@ members = [
     "store",
     "core"
 ]
+resolver = "1"

--- a/cli/templates/core/Cargo.toml.tt
+++ b/cli/templates/core/Cargo.toml.tt
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cali_core = "0.2.0"
+cali_core = "{core_version}"
 {name}_store = \{ version = "*", path = "../store" }

--- a/cli/templates/store/Cargo.toml.tt
+++ b/cli/templates/store/Cargo.toml.tt
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cali_core = "0.2.0"
-cali_derive = "0.2.0"
+cali_core = "{core_version}"
+cali_derive = "{derive_version}"
 
 tokio = \{ version = "1.6", features = ["rt-multi-thread", "time", "macros", "signal", "process"] }
 chrono = \{ version = "0.4", features = ["serde"] }

--- a/cli/templates/web/Cargo.toml.tt
+++ b/cli/templates/web/Cargo.toml.tt
@@ -10,8 +10,8 @@ path = "src/entry/main.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cali_core = "0.2.0"
-cali_derive = "0.2.0"
+cali_core = "{core_version}"
+cali_derive = "{derive_version}"
 
 tokio = \{ version = "1.32", features = ["rt-multi-thread", "time", "macros", "signal", "process"] }
 tonic = \{ version = "0.9.2", features = ["tls", "codegen"] }
@@ -27,7 +27,7 @@ log = "0.4.17"
 thiserror = "1.0"
 
 [build-dependencies]
-cali_core = "0.2.0"
-cali_derive = "0.2.0"
+cali_core = "{core_version}"
+cali_derive = "{derive_version}"
 tonic-build = "0.9.2"
 convert_case = "0.5.0"

--- a/cli/templates/web/src/entry/main.rs.tt
+++ b/cli/templates/web/src/entry/main.rs.tt
@@ -1,3 +1,4 @@
+use cali_core::config::CaliConfig;
 use {name}_web::config::Config;
 use cali_derive::setup_server;
 use std::\{error::Error, str::FromStr};
@@ -8,7 +9,7 @@ pub struct ServerContext \{}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> \{
-    let my_context = Arc::new(ServerContext \{});
-    setup_server!("{name}", "0.1.1", my_context);
+    let server_config: CaliConfig<ServerContext, _, _> = CaliConfig::new().enable_database();
+    setup_server!("{name}", "0.1.1", server_config);
     Ok(())
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cali_core"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Cali is a batteries included, opinionated rust based microservice framework."

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -1,1 +1,40 @@
+use std::sync::Arc;
 
+use tonic::transport::Server;
+
+pub struct CaliConfig<T, Stack, ResultStack> {
+    pub global_context: Option<Arc<T>>,
+    pub database: bool,
+    pub middleware_setup: Option<Box<dyn FnOnce(Server<Stack>) -> Server<ResultStack>>>,
+}
+
+impl<T, Stack, ResultStack> CaliConfig<T, Stack, ResultStack> {
+    pub fn new() -> Self {
+        Self {
+            database: false,
+            global_context: None,
+            middleware_setup: None,
+        }
+    }
+
+    pub fn enable_database(mut self) -> Self {
+        self.database = true;
+
+        self
+    }
+
+    pub fn add_middleware(
+        mut self,
+        setup_fn: impl FnOnce(Server<Stack>) -> Server<ResultStack> + 'static,
+    ) -> Self {
+        self.middleware_setup = Some(Box::new(setup_fn));
+
+        self
+    }
+
+    pub fn add_global_context(mut self, global_context: T) -> Self {
+        self.global_context = Some(Arc::new(global_context));
+
+        self
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod store;
 
 #[derive(Debug, Clone)]
 pub struct ServerContext {
-    pub db_pool: sqlx::MySqlPool,
+    pub db_pool: Option<sqlx::MySqlPool>,
 }
 
 pub type MapKey = Arc<dyn Any + Send + Sync>;

--- a/core/src/middleware/server_context.rs
+++ b/core/src/middleware/server_context.rs
@@ -16,7 +16,7 @@ pub struct ServerContextLayer<
     I: 'static + Send + Sync,
     C: 'static + Send + Sync,
 > {
-    pub extentable_context: Arc<T>,
+    pub extendable_context: Option<Arc<T>>,
     pub internal_context: Arc<I>,
     pub config: Arc<C>,
 } // Internal + a open struct for other people
@@ -31,7 +31,9 @@ where
 
     fn layer(&self, service: S) -> Self::Service {
         let mut context: HashMap<TypeId, MapKey> = HashMap::new();
-        context.insert(TypeId::of::<T>(), self.extentable_context.clone());
+        if let Some(extendable_context) = &self.extendable_context {
+            context.insert(TypeId::of::<T>(), extendable_context.clone());
+        }
         context.insert(TypeId::of::<I>(), self.internal_context.clone());
         context.insert(TypeId::of::<C>(), self.config.clone());
         ServerContextService {

--- a/core/src/store/mod.rs
+++ b/core/src/store/mod.rs
@@ -6,6 +6,10 @@ pub mod snare;
 
 pub async fn get_conn<T: From<sqlx::Error>>() -> Result<PoolConnection<MySql>, T> {
     let svr_ctx = get_context(|core_ctx: &ServerContext| core_ctx.clone());
-    let conn = svr_ctx.db_pool.acquire().await?;
+    let conn = svr_ctx
+        .db_pool
+        .expect("Database isn't enabled in cali config, why are you asking me for a connection?")
+        .acquire()
+        .await?;
     Ok(conn)
 }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cali_derive"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "Contains the macro's used to simplify a Cali project's setup & testing."
@@ -14,5 +14,5 @@ syn = { version = "2.0" }
 quote = "1.0"
 convert_case = "0.5.0"
 proc-macro2 = { version = "1.0.66", features = ["default", "span-locations"] }
-cali_core = "0.2.1"
+cali_core = "0.3.0"
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -14,5 +14,5 @@ syn = { version = "2.0" }
 quote = "1.0"
 convert_case = "0.5.0"
 proc-macro2 = { version = "1.0.66", features = ["default", "span-locations"] }
-cali_core = "0.2.0"
+cali_core = "0.2.1"
 


### PR DESCRIPTION
Experimenting with a CaliConfig struct that will allow users to dynamically configure their project using the builder pattern.

This version works pretty well, but some issues that I've encountered:

- You have to specify a global context datatype and have to specify the type when you setup the config, even if you don't want to add global context. I need to spend more time looking at this.
- ~~You have to specify the input and output layer stacks if there is no GRPC services setup, which means this currently breaks with a `cali new <project>` scaffold.~~ Fixed by reorganizing the server segment.
